### PR TITLE
Google Auth 401 Fixes

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -25,7 +25,7 @@ export const authOptions: NextAuthOptions = {
       clientSecret: env.GOOGLE_CLIENT_SECRET,
       authorization: {
         params: {
-          prompt: "consent",
+          prompt: "login",
           access_type: "offline",
           response_type: "code",
           scope:

--- a/src/pages/api/drive/addfile.ts
+++ b/src/pages/api/drive/addfile.ts
@@ -24,15 +24,15 @@ const uploadToFolder = async (req: NextApiRequest, res: NextApiResponse) => {
     mimeType: "application/vnd.google-apps.document",
     parents: [parentID],
   };
-  const media = {
-    mimeType: "text/plain",
-    body: fileData.description,
-  };
+  // const media = {
+  //   mimeType: "text/plain",
+  //   body: fileData.description,
+  // };
 
   try {
     const file = await (service as NonNullable<typeof service>).files.create({
       resource: fileMetadata,
-      media: media,
+      // media: media,
       fields: "id",
     });
     const googleFileId = (file as any).data.id;


### PR DESCRIPTION
- only prompts for first sign-in for scopes
- makes empty google docs
- description doesn't write into docs anymore (was the reason behind the 401 invalid credentials)