### PR TITLE
Patch useThrottleApi loading indicator

### DIFF
--- a/src/hooks/useApiThrottle.tsx
+++ b/src/hooks/useApiThrottle.tsx
@@ -14,6 +14,7 @@ interface UseApiThrottleProps<T extends ApiCall> {
 const useApiThrottle = <T extends ApiCall>(props: UseApiThrottleProps<T>) => {
   const { fn, callback } = props;
   const fetchingRef = React.useRef(false);
+  const [fetching, setFetching] = React.useState(false);
 
   const wrapperFn: (...args: Parameters<T>) => Promise<void> =
     React.useCallback(
@@ -21,15 +22,16 @@ const useApiThrottle = <T extends ApiCall>(props: UseApiThrottleProps<T>) => {
         if (fetchingRef.current) {
           return;
         }
-        console.log("Executing");
         fetchingRef.current = true;
+        setFetching(true);
         await fn(...args).then(callback);
         fetchingRef.current = false;
+        setFetching(false);
       },
       [fn, callback]
     );
 
-  return { fetching: fetchingRef.current, fn: wrapperFn };
+  return { fetching, fn: wrapperFn };
 };
 
 export default useApiThrottle;


### PR DESCRIPTION
# Description

- `useApiThrottle` returns `ref.current` which is bad practice when rendering UI.
- Add a `useState` for caller to determine rendering logic.